### PR TITLE
refactor(commands): streamline git-ship to automate branch/push/PR with manual stage & commit

### DIFF
--- a/claude/commands/git-ship.md
+++ b/claude/commands/git-ship.md
@@ -1,10 +1,13 @@
 ---
-description: "Full git ship workflow: create branch, commit, and open a PR."
+description: "Auto-ship with branch creation, push, and PR fully automated. Stage and commit require user confirmation. Blocks on default branch."
 ---
 
 # Git Ship
 
-Run the full git workflow: branch creation → commit → PR.
+Run the full git workflow: branch creation → stage & commit (with confirmation) → push → PR.
+
+Branch creation, push, and PR creation are fully automatic.
+Stage and commit require explicit user confirmation.
 
 ## Workflow
 
@@ -12,24 +15,22 @@ Run the full git workflow: branch creation → commit → PR.
    - Run `git status` to confirm there are changes to ship.
    - If the tree is clean, stop and notify the user.
 
-2. **Create branch**
+2. **Create branch** *(automatic)*
    - Analyze `git status` and `git diff` to infer the type (`feat` / `fix` / `chore` / `refactor` / `docs` / `test` / `ci` / `perf` / `style`) and a short kebab-case description of the changes.
-   - Propose a branch name in the format `<type>/<short-description>` (e.g. `feat/add-git-ship-command`).
-   - Show the proposed branch name to the user and accept confirmation or corrections.
-   - After confirmation, check whether the branch already exists.
-   - If it does not exist, run `git switch -c <branch-name>`.
+   - Determine branch name in the format `<type>/<short-description>` (e.g. `feat/add-git-ship-command`).
+   - Check whether the branch already exists.
+   - If it does not exist, run `git switch -c <branch-name>` and report the created branch name.
    - If it already exists, stop and ask the user whether to switch to it or choose a different name.
 
-3. **Stage changes**
-   - Show the unstaged file list with `git status --short`.
-   - Ask the user to confirm the files to include before staging.
-   - Stage only the confirmed files instead of using `git add .`.
+3. **Stage & Commit** *(requires confirmation)*
+   - Show the list of changed files with `git status --short`.
+   - Show the diff with `git diff`.
+   - Ask the user to confirm which files to stage and whether the changes are correct.
+   - After confirmation, stage the selected files.
    - Show a summary of staged files via `git diff --cached --stat`.
    - If sensitive-looking files (e.g. `.env`, secrets) are staged, ask for confirmation before continuing.
-
-4. **Commit**
    - Analyze `git diff --cached` to infer the commitizen type (`feat` / `fix` / `chore` / `refactor` / `docs` / `test` / `ci` / `perf` / `style`), scope, and subject.
-   - Show the proposed commit message to the user and accept confirmation or corrections.
+   - Show the proposed commit message and ask the user to confirm or correct it.
    - Before running the commit command, verify that `npx` and `git-cz` are available in the current environment.
    - If the required tooling is unavailable, stop and report the missing prerequisite clearly.
    - After confirmation, run:
@@ -38,12 +39,16 @@ Run the full git workflow: branch creation → commit → PR.
      ```
    - Omit `--scope` when no meaningful scope applies.
 
+4. **Push** *(automatic)*
+   - If the current branch is `main` or `master`, stop immediately and report to the user. Do not push.
+   - Run `git push -u origin <branch-name>` and report the result.
+
 5. **Generate PR description**
    - Run `/write-pr-description` to draft the PR body.
 
-6. **Open PR**
+6. **Open PR** *(automatic)*
    - Build the PR title as `<type>: <subject>` when there is no scope, or `<type>(<scope>): <subject>` when scope is present.
-   - Use the generated PR body to run:
+   - Run:
      ```
      gh pr create --title "<pr-title>" --body "<pr-body>" -w
      ```
@@ -51,7 +56,7 @@ Run the full git workflow: branch creation → commit → PR.
 
 ## Rules
 
+- Always block when the current branch is `main` or `master`. Never push to the default branch.
 - Never skip confirmation when sensitive-looking files are staged.
-- Never bulk-stage all changes without explicit user confirmation.
 - Do not force-push or amend published commits.
 - If any step fails, stop immediately and report the error clearly.


### PR DESCRIPTION
## Why this change

The previous `git-ship` command prompted for confirmation at every step (branch name, files to stage, commit message, PR creation), which created unnecessary friction for routine workflows.

The goal is to reduce cognitive overhead by automating decisions that are mechanical and low-risk, while keeping confirmation for steps where human judgment matters most: reviewing what's staged and approving the commit message.

## What changed

- **Branch creation**: now fully automatic — branch name is inferred from diff and created without prompting
- **Push**: now fully automatic — runs immediately after commit
- **PR creation**: now fully automatic — title and body are generated and submitted without a confirmation step
- **Stage & Commit**: unchanged as a confirmation step — user reviews changed files, diff, and proposed commit message before proceeding
- **Default branch guard**: moved from step 2 (pre-branch-creation) to step 4 (pre-push), which is the actual point of risk

## Impact

Faster ship flow with fewer interruptions. The only interaction point is the stage & commit review, which is intentional.

## Risks

Low. The change is to a local Claude Code slash command definition only — no application code is modified. Worst case: revert `claude/commands/git-ship.md` to the previous version.